### PR TITLE
Update weather.service.ts to use the free open-meteo.com api

### DIFF
--- a/api/src/api/services/weather.service.ts
+++ b/api/src/api/services/weather.service.ts
@@ -9,7 +9,7 @@ export const handleGetWeather = async (ctx: Context) => {
 
   const OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast";
   const res = await fetch(
-    `${OPEN_METEO_URL}?latitude=${lat}&longitude=${lon}&hourly=temperature_2m`
+    `${OPEN_METEO_URL}?latitude=${lat}&longitude=${lon}&hourly=temperature_2m,`
   );
 
   const resData = await res.json();

--- a/api/src/api/services/weather.service.ts
+++ b/api/src/api/services/weather.service.ts
@@ -6,13 +6,10 @@ export const handleGetWeather = async (ctx: Context) => {
 
   const lat = searchParams.get("lat") || "1";
   const lon = searchParams.get("lon") || "1";
-  const units = searchParams.get("units") || "metric";
 
-  const OPEN_WEATHER_URL = process.env.OPEN_WEATHER_URL;
-  const OPEN_WEATHER_API_KEY = process.env.OPEN_WEATHER_API_KEY;
-
+  const OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast";
   const res = await fetch(
-    `${OPEN_WEATHER_URL}/data/3.0/onecall?lat=${lat}&lon=${lon}&exclude=minutely,alerts&appid=${OPEN_WEATHER_API_KEY}&units=${units}`
+    `${OPEN_METEO_URL}?latitude=${lat}&longitude=${lon}&hourly=temperature_2m`
   );
 
   const resData = await res.json();


### PR DESCRIPTION
This pull request includes a change to the weather service API to switch from the OpenWeather API to the Open-Meteo API. The most important changes include updating the URL and parameters used for fetching weather data.

Changes to weather service API:

* [`api/src/api/services/weather.service.ts`](diffhunk://#diff-72d6c1d91da19326edc11ce91733d14e5c92098a8b25ebca6896a8190b419a28L9-R12): Replaced the OpenWeather API URL and parameters with the Open-Meteo API URL and parameters. Removed the `units` parameter and environment variables for the OpenWeather API URL and key.